### PR TITLE
Support pipes on one line?

### DIFF
--- a/04-pipes.Rmd
+++ b/04-pipes.Rmd
@@ -15,6 +15,8 @@ foo_foo %>%
   scoop(up = field_mouse) %>%
   bop(on = head)
 
+foo_foo %>% fall("asleep")
+
 # Bad
 foo_foo <- hop(foo_foo, through = forest)
 foo_foo <- scoop(foo_foo, up = field_mice)
@@ -43,6 +45,34 @@ Avoid using the pipe when:
 * There are meaningful intermediate objects that could be given
   informative names.
 
+There's one exception to this rule: sometimes it's useful to include a short
+pipe as an argument to a function in a longer pipe. Carefully consider whether
+the code is more readable with a short inline pipe (which doesn't require a
+lookup elsewhere) or if it's better to move the code outside the pipe and give
+it an evocative name.
+
+```{r, eval = FALSE}
+# Good
+x %>%
+  select(a, b, w) %>%
+  left_join(y %>% select(a, b, v), by = c("a", "b"))
+
+x_join <-
+  x %>%
+  select(a, b, w)
+y_join <-
+  y %>%
+  filter(!u) %>%
+  gather(a, v, -b) %>%
+  select(a, b, v)
+left_join(x_join, y_join, by = c("a", "b"))
+
+# Bad
+x %>%
+  select(a, b, w) %>%
+  left_join(y %>% filter(!u) %>% gather(a, v, -b) %>% select(a, b, v), by = c("a", "b"))
+```
+
 ## Spacing and indenting
 
 `%>%` should always have a space before it and a new line after it. After the 
@@ -61,15 +91,6 @@ iris %>%
 iris %>% group_by(Species) %>% summarize_all(mean) %>%
 ungroup %>% gather(measure, value, -Species) %>%
 arrange(value)
-```
-
-It is ok to keep a one-step pipe on one line, although depending on the 
-context, you may want to rewrite to remove the pipe.
-
-```{r, eval = FALSE}
-# Good
-iris %>% arrange(Petal.Width)
-arrange(iris, Petal.Width)
 ```
 
 ## No arguments
@@ -107,12 +128,31 @@ iris %>%
 
 ## Assignment
 
-You can use `->` to create an object at the end of the pipe.
+Use a separate line for the target of the assignment followed by `<-`.
 
-Personally, I think you should avoid this technique. While starting with the 
+Personally, I think you should avoid using `->` to create an object at the end of the pipe. While starting with the 
 assignment is a little more work when writing the code, it makes reading the 
 code easier. This is because the name acts as a heading, which reminds you of 
 the purpose of the pipe.
+
+```{r, eval = FALSE}
+# Good
+iris_long <-
+  iris %>%
+  gather(measure, value, -Species) %>%
+  arrange(-value)
+
+# Bad
+iris_long <- iris %>%
+  gather(measure, value, -Species) %>%
+  arrange(-value)
+
+iris %>%
+  gather(measure, value, -Species) %>%
+  arrange(-value) ->
+  iris_long
+```
+
 
 ## Comments
 


### PR DESCRIPTION
This is necessary in particular for pipes used as an argument to a function call, e.g. in a join:

```r
lhs %>%
  select(a, b) %>%
  left_join(rhs %>% select(a, c), by = "a")
```

@hadley: Can you please take a look?