### PR TITLE
Named arguments and line breaks in function calls

### DIFF
--- a/02-syntax.Rmd
+++ b/02-syntax.Rmd
@@ -188,15 +188,13 @@ Strive to limit your code to 80 characters per line. This fits comfortably on a
 printed page with a reasonably sized font. If you find yourself running out of 
 room, this is a good indication that you should encapsulate some of the work in 
 a separate function.
-
 If a function call is too long to fit on a single line, use one line each for 
-the function name, each argument, and the closing `)`. This makes the code 
-easier to read and to change later. 
-
+the function name, each argument, and the closing `)`. 
+This makes the code easier to read and to change later. 
 ```{r, eval = FALSE}
 # Good
 do_something_very_complicated(
-  "that",
+  something = "that",
   requires = many,
   arguments = "some of which may be long"
 )
@@ -205,6 +203,17 @@ do_something_very_complicated(
 do_something_very_complicated("that", requires, many, arguments,
                               "some of which may be long"
                               )
+```
+
+As described under [Argument names], you can omit the argument names
+for very common arguments (i.e. for arguments that are used in almost every 
+invocation of the function). Unnamed arguments also go on the same line as the
+function name, even if the whole function call spans multiple lines.
+```{r, eval = FALSE}
+map(x, f,
+  extra_argument_a = 10,
+  extra_argument_b = c(1, 43, 390, 210209)
+)
 ```
 
 You may also place several arguments on the same line if they are closely 

--- a/02-syntax.Rmd
+++ b/02-syntax.Rmd
@@ -207,8 +207,8 @@ do_something_very_complicated("that", requires, many, arguments,
 
 As described under [Argument names], you can omit the argument names
 for very common arguments (i.e. for arguments that are used in almost every 
-invocation of the function). Unnamed arguments also go on the same line as the
-function name, even if the whole function call spans multiple lines.
+invocation of the function). Short unnamed arguments can also go on the same 
+line as the function name, even if the whole function call spans multiple lines.
 ```{r, eval = FALSE}
 map(x, f,
   extra_argument_a = 10,


### PR DESCRIPTION
Closes #39. Regarding the fact that unnamed arguments are special (https://github.com/tidyverse/style/issues/39#issuecomment-355759286), I made reference to the section **Named arguments** and repeated when argument names can be omitted.