### PR TITLE
Change "Breaking changes" to "Interface-breaking changes"

### DIFF
--- a/08-news.Rmd
+++ b/08-news.Rmd
@@ -29,7 +29,7 @@ Prior to release, the NEWS file needs to be thoroughly proof read and groomed. I
 If there are API breaking changes, these should appear at the top, including a description of the symptoms of the change, and what is needed to fix it.
 
 ```
-## Breaking changes
+## Interface-breaking changes
 
 * `separate()` now correctly uses -1 to refer to the far right position, 
   instead of -2. If you depended on this behaviour, you'll need to condition


### PR DESCRIPTION
Because I always think this means "breaking news" when I see it that way - and also because it's easy to misread it as a gerund rather than an adjective, i.e. "here's how to break changes" (similar to "Documenting methods" or "Writing functions") rather than the intended "here's what changes might break things".