### PR TITLE
Avoid evaluating quoting example

### DIFF
--- a/02-syntax.Rmd
+++ b/02-syntax.Rmd
@@ -256,7 +256,7 @@ on one line.
 Use `"`, not `'`, for quoting text. The only exception is when the text already 
 contains double quotes and no single quotes.
 
-```{r}
+```{r, eval=FALSE}
 # Good
 "Text"
 'Text with "quotes"'


### PR DESCRIPTION
If this code gets evaluated, it produces some undesirable noise:

<img width="350" alt="screen shot 2018-02-15 at 11 41 44 pm" src="https://user-images.githubusercontent.com/111939/36294961-e5673cda-12a9-11e8-8fc6-ad1f03f00f38.png">
