### PR TITLE
fix typos

### DIFF
--- a/02-syntax.Rmd
+++ b/02-syntax.Rmd
@@ -121,8 +121,8 @@ Avoid partial matching.
 
 ## Indenting
 
-Curly braces, `{}`, define the the most important hierarchy of R code. To make 
-this hierarchy easy to see, always indent the code inside `{}` by two spaces.
+Curly braces, `{}`, define the most important hierarchy of R code. To make this 
+hierarchy easy to see, always indent the code inside `{}` by two spaces.
 
 A symmetrical arrangement helps finding related braces: The opening brace is the
 last, the closing brace is the first non-whitespace character in a line.  Code

--- a/07-errors.Rmd
+++ b/07-errors.Rmd
@@ -10,7 +10,7 @@ An error message should start with a general statement of the problem then give 
 
 ## Problem statement
 
-Every error message should start with general statement of the problem. It should be concise, but informative. (This is hard!)
+Every error message should start with a general statement of the problem. It should be concise, but informative. (This is hard!)
 
 *   If the cause of the problem is clear use "must":
 
@@ -132,8 +132,8 @@ Good hints are difficult to write because, as above, you want to avoid steering 
 ## Punctuation
 
 *   Errors should be written in sentence case, and should end in a full stop.
-    Bullets should formatted similarly; make sure to capitalise the first word
-    (unless it's an argument or column name).
+    Bullets should be formatted similarly; make sure to capitalise the first
+    word (unless it's an argument or column name).
     
 *   Prefer the singular in problem statements:
 

--- a/08-news.Rmd
+++ b/08-news.Rmd
@@ -4,9 +4,9 @@
 
 Each user-facing change should be accompanied by a bullet in `NEWS.md`. The goal of the bullet is to:
 
-* Briefly describe the change, starting with the name of function. This can be
-  similar to the commit message, but often the commit message will be developer 
-  facing, and the bullet will be user facing.
+* Briefly describe the change, starting with the name of the function. This can
+  be similar to the commit message, but often the commit message will be
+  developer facing, and the bullet will be user facing.
 
 * Link to the related issue, if present.
 


### PR DESCRIPTION
- chapter 2: remove duplicate "the"
- chapter 7: insert "a", insert "be"
- chapter 8: insert "the"