### PR TITLE
Adding rule on tilde

### DIFF
--- a/02-syntax.Rmd
+++ b/02-syntax.Rmd
@@ -45,6 +45,8 @@ mean <- function(x) sum(x)
 Put a space before and after `=` when naming arguments in function calls.
 Most infix operators (`==`, `+`, `-`, `<-`, etc.) are also surrounded by
 spaces, except those with relatively high precedence: `^`, `:`, `::`, and `:::`.
+Tildes (`~`) in formulas with both LHS and RHS are surrounded by a space, if 
+there is no LHS, put no space after `~`. 
 
 Always put a space after a comma,
 and never before (just like in regular English).  Prefer parentheses over
@@ -56,12 +58,18 @@ average <- mean((feet / 12) + inches, na.rm = TRUE)
 sqrt(x^2 + y^2)
 x <- 1:10
 base::get
+y ~ x
+tribble( 
+  ~col1, ~col2,
+  "a", "b"
+)
 
 # Bad
 average<-mean(feet/12 + inches,na.rm=TRUE)
 sqrt(x ^ 2 + y ^ 2)
 x <- 1 : 10
 base :: get
+y~x
 ```
 
 Place a space before `(`, except when it's part of a function call.


### PR DESCRIPTION
Makes convention on R formulas explicit with a rule for spacing around tilde.
Origin: https://github.com/tidyverse/dplyr/commit/0818cab40c109b88777b7c4e9e6b768dcca4e8c0#r28072638 
Reference above not linked properly, look for 
> "The general R convention is to put spaces when there is a LHS and no space when there is not."