### PR TITLE
Edit copy for grammar and consistency.

### DIFF
--- a/02-syntax.Rmd
+++ b/02-syntax.Rmd
@@ -13,7 +13,7 @@ Use underscores (`_`) to separate words within a name. Base R uses dots in
 function names (`contrib.url()`) and class names (`data.frame`), but it's 
 better to reserve dots exclusively for the S3 object system. In S3, methods are 
 given the name `function.class`; if you also use `.` in function and class 
-names you end up with confusing methods like `as.data.frame.data.frame()`.
+names, you end up with confusing methods like `as.data.frame.data.frame()`.
 
 Generally, variable names should be nouns and function names should be verbs. 
 Strive for names that are concise and meaningful (this is not easy!).
@@ -44,9 +44,9 @@ mean <- function(x) sum(x)
 
 Put a space before and after `=` when naming arguments in function calls.
 Most infix operators (`==`, `+`, `-`, `<-`, etc.) are also surrounded by
-spaces, except those with relatively high precedence: `^`, `:`, `::`, and `:::`.
-Tildes (`~`) in formulas with both LHS and RHS are surrounded by a space, if 
-there is no LHS, put no space after `~`. 
+spaces, except those with relatively [high precedence](http://stat.ethz.ch/R-manual/R-patched/library/base/html/Syntax.html): 
+`^`, `:`, `::`, and `:::`. Tildes (`~`) in formulas with both LHS and RHS are 
+surrounded by a space, if there is no LHS, put no space after `~`. 
 
 Always put a space after a comma, never before, just like in regular English.  
 To highlight operator precedence, use parentheses rather than irregular spacing.
@@ -69,6 +69,10 @@ sqrt(x ^ 2 + y ^ 2)
 x <- 1 : 10
 base :: get
 y~x
+tribble( 
+  ~col1, ~col2 ,
+  "a" , "b"
+)
 ```
 
 Place a space before `(`, except when it's part of a function call.
@@ -107,7 +111,7 @@ x[1,]   # Needs a space after the comma
 x[1 ,]  # Space goes after comma not before
 ```
 
-Do not put a space after the tidy evaluation bang-bang (`!!`) and bang-bang-bang (`!!!`) operators. 
+Do not put a space after the tidy evaluation bang-bang (`!!`) or bang-bang-bang (`!!!`) operators. 
 
 ```{r, eval = FALSE}
 # Good
@@ -122,10 +126,10 @@ call(! !xyz)
 ## Argument names
 
 A function's arguments typically fall into two broad categories: one supplies 
-the __data__ to compute on; the other controls __details__ of computation. When 
-you call a function, you typically omit the names of data arguments, because 
-they are used so commonly. If you override the default value of an argument, 
-use the full name:
+the __data__ to compute on; the other controls the __details__ of computation. 
+When you call a function, you typically omit the names of data arguments, 
+because they are used so commonly. If you override the default value of an 
+argument, use the full name:
 
 ```{r, eval = FALSE}
 # Good
@@ -143,10 +147,10 @@ Avoid partial matching.
 Curly braces, `{}`, define the most important hierarchy of R code. To make this 
 hierarchy easy to see, always indent the code inside `{}` by two spaces.
 
-A symmetrical arrangement helps finding related braces: The opening brace is the
-last, the closing brace is the first non-whitespace character in a line.  Code
-that is related to a brace (e.g., an `if` clause, a function declaration, a
-trailing comma, ...) must be on the same line.
+A symmetrical arrangement helps with finding related braces: the opening brace 
+is the last, the closing brace is the first non-whitespace character in a line.  
+Code that is related to a brace (e.g., an `if` clause, a function declaration, a
+trailing comma, ...) must be on the same line as the opening brace.
 
 ```{r, eval = FALSE}
 # Good
@@ -207,9 +211,11 @@ Strive to limit your code to 80 characters per line. This fits comfortably on a
 printed page with a reasonably sized font. If you find yourself running out of 
 room, this is a good indication that you should encapsulate some of the work in 
 a separate function.
+
 If a function call is too long to fit on a single line, use one line each for 
 the function name, each argument, and the closing `)`. 
 This makes the code easier to read and to change later. 
+
 ```{r, eval = FALSE}
 # Good
 do_something_very_complicated(
@@ -228,6 +234,7 @@ As described under [Argument names], you can omit the argument names
 for very common arguments (i.e. for arguments that are used in almost every 
 invocation of the function). Short unnamed arguments can also go on the same 
 line as the function name, even if the whole function call spans multiple lines.
+
 ```{r, eval = FALSE}
 map(x, f,
   extra_argument_a = 10,

--- a/03-functions.Rmd
+++ b/03-functions.Rmd
@@ -37,7 +37,8 @@ long_function_name <- function(a = "a long argument",
 ```
 
 ## `return()`
-Only use `return()` for early returns. Otherwise rely on R to return the result 
+
+Only use `return()` for early returns. Otherwise, rely on R to return the result 
 of the last evaluated expression.
 
 ```{r eval = FALSE}
@@ -59,7 +60,7 @@ add_two <- function(x, y) {
 If your function is called primarily for its side-effects (like printing, 
 plotting, or saving to disk), it should return the first argument invisibly. 
 This makes it possible to use the function as part of a pipe. `print` methods 
-should usually do this, like this example from httr:
+should usually do this, like this example from [httr](http://httr.r-lib.org/):
 
 ```{r eval = FALSE}
 print.url <- function(x, ...) {

--- a/04-pipes.Rmd
+++ b/04-pipes.Rmd
@@ -75,8 +75,8 @@ x %>%
 
 ## Spacing and indenting
 
-`%>%` should always have a space before it and a new line after it. After the 
-first step, each line should be indented by two spaces.
+`%>%` should always have a space before it. After the first step, each line 
+should be indented by two spaces.
 
 ```{r, eval = FALSE}
 # Good
@@ -130,10 +130,10 @@ iris %>%
 
 Use a separate line for the target of the assignment followed by `<-`.
 
-Personally, I think you should avoid using `->` to create an object at the end of the pipe. While starting with the 
-assignment is a little more work when writing the code, it makes reading the 
-code easier. This is because the name acts as a heading, which reminds you of 
-the purpose of the pipe.
+Personally, I think you should avoid using `->` to create an object at the end 
+of the pipe. While starting with the assignment is a little more work when 
+writing the code, it makes reading the code easier. This is because the name 
+acts as a heading, which reminds you of the purpose of the pipe.
 
 ```{r, eval = FALSE}
 # Good

--- a/06-documentation.Rmd
+++ b/06-documentation.Rmd
@@ -6,8 +6,8 @@
 
 Documentation of code is essential, even if the only person using your code 
 is future-you. Use [roxygen2](https://github.com/klutometis/roxygen) with 
-enabled [markdown](https://github.com/klutometis/roxygen/blob/master/vignettes/markdown.Rmd)
-support to keep your documentation close to the code.
+[markdown](https://github.com/klutometis/roxygen/blob/master/vignettes/markdown.Rmd)
+support enabled to keep your documentation close to the code.
 
 ```{r, include=FALSE}
 knitr::opts_chunk$set(eval = FALSE)
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(eval = FALSE)
 
 For the title, describe concisely what the function does in the very 
 first line of your function documentation. Titles should use sentence case 
-but not end with a full stop.
+but not end with a full stop (`.`).
 
 ```{r}
 #' Combine values into a vector or list
@@ -108,8 +108,8 @@ function calls.
 
 If you have a family of related functions, you can use the `@family` tag to 
 automatically add appropriate lists and interlinks to the `@seealso` section.
-Family names are plural. In dplyr, the verbs `arrange`, `filter`, `mutate`,
-`slice`, `summarize` form the family of single table verbs.
+Family names are plural. In dplyr, the verbs `arrange()`, `filter()`, 
+`mutate()`, `slice()`, `summarize()` form the family of single table verbs.
 
 ```{r}
 #' @family single table verbs
@@ -149,14 +149,15 @@ the roxygen comments.
 
 ## `Code font`
 
-Text that contains valid R code should be marked as such.
+Text that contains valid R code should be marked as such using backticks.
 
-* Function names, which should be followed by `()`, e.g. `tibble()`.
+* Function names should be followed by `()`, e.g. `tibble()`.
 * Function arguments, e.g. `na.rm`. 
 * Values, e.g. `TRUE`, `FALSE`, `NA`, `NaN`, `...`, `NULL` 
 * Literal R code, e.g. `mean(x, na.rm = TRUE)`
 
-Do not use code font for package names. If package name is ambiguous in the context, disambiguate with words, e.g. "the foo package".
+Do not use code font for package names. If package name is ambiguous in the 
+context, disambiguate with words, e.g. "the foo package".
 
 ## Internal functions
 

--- a/07-errors.Rmd
+++ b/07-errors.Rmd
@@ -4,64 +4,77 @@
 knitr::opts_chunk$set(eval = FALSE)
 ```
 
-An error message should start with a general statement of the problem then give a concise description of what went wrong. Consistent use of punctuation and formatting makes errors easier to parse.
+An error message should start with a general statement of the problem then give
+a concise description of what went wrong. Consistent use of punctuation and
+formatting makes errors easier to parse.
 
-(This guide is currently almost entirely aspirational; most of the bad examples come from existing tidyverse code.)
+(This guide is currently almost entirely aspirational; most of the bad examples
+come from existing tidyverse code.)
 
 ## Problem statement
 
-Every error message should start with a general statement of the problem. It should be concise, but informative. (This is hard!)
+Every error message should start with a general statement of the problem. It
+should be concise, but informative. (This is hard!)
 
 *   If the cause of the problem is clear use "must":
 
     ```{r}
     dplyr::nth(1:10, "x")
-    #> Error: `n` must be a numeric vector, not a character vector
+    #> Error: `n` must be a numeric vector, not a character vector.
     
     dplyr::nth(1:10, 1:2)
-    #> Error: `n` must have length 1, not length 2
+    #> Error: `n` must have length 1, not length 2.
     ```
     
     Clear cut causes typically involve incorrect types or lengths.
 
-*   If you can't state what was expected, use "can't":
+*   If you cannot state what was expected, use "can't":
 
     ```{r}
     mtcars %>% pull(b)
-    #> Error: Can't find column `b` in `.data`
+    #> Error: Can't find column `b` in `.data`.
     
     as_vector(environment())
-    #> Error: Can't coerce `.x` to a vector
+    #> Error: Can't coerce `.x` to a vector.
     
     purrr::modify_depth(list(list(x = 1)), 3, ~ . + 1)
-    #> Error: Can't find specified `.depth` in `.x`
+    #> Error: Can't find specified `.depth` in `.x`.
     ```
 
-Use `stop(call. = FALSE)`, `rlang::abort()`, `Rf_errorcall(R_NilValue, ...)` to avoid cluttering the error message with the name of the function that generated it. That information is often not informative, and can easily be accessed via `traceback()` or IDE equivalent.
+Use `stop(call. = FALSE)`, `rlang::abort()`, `Rf_errorcall(R_NilValue, ...)` to
+avoid cluttering the error message with the name of the function that generated
+it. That information is often not informative, and can easily be accessed via
+`traceback()` or an IDE equivalent.
 
 ## Error location
 
-Do your best to reveal the location, name, and/or content of the troublesome component. The goal is to make it easy as possible for the user to find and fix the problem.
+Do your best to reveal the location, name, and/or content of the troublesome
+component. The goal is to make it easy as possible for the user to find and fix
+the problem.
 
 ```{r}
 # GOOD
 map_int(1:5, ~ "x")
 #> Error: Each result must be a single integer:
-#> * Result 1 is a character vector
+#> * Result 1 is a character vector.
 
 # BAD
 map_int(1:5, ~ "x")
 #> Error: Each result must be a single integer
 ```
 
-(It is often not easy to identify the exact problem; it may require passing around extra arguments so that error messages generated at a lower-level can know the original source. For frequently used functions, the effort is typically worth it.)
+(It is often not easy to identify the exact problem; it may require passing
+around extra arguments so that error messages generated at a lower-level can
+know the original source. For frequently used functions, the effort is typically
+worth it.)
 
-If the source of the error is unclear, avoid pointing the user in the wrong direction by giving an opinion about the source of the error:
+If the source of the error is unclear, avoid pointing the user in the wrong
+direction by giving an opinion about the source of the error:
 
 ```{r}
 # GOOD
 pull(mtcars, b)
-#> Error: Can't find column `b` in `.data`
+#> Error: Can't find column `b` in `.data`.
 
 tibble(x = 1:2, y = 1:3, z = 1)
 #> Error: Columns must have consistent lengths: 
@@ -79,7 +92,8 @@ tibble(x = 1:2, y = 1:3, z = 1)
 #> Error: Column `x` must be length 1 or 3, not 2 
 ```
 
-If there are multiple issues, or an inconsistency revealed across several arguments or items, prefer a bulleted list:
+If there are multiple issues, or an inconsistency revealed across several
+arguments or items, prefer a bulleted list:
 
 ```{r}
 # GOOD
@@ -96,11 +110,12 @@ purrr::reduce2(1:4, 1:2, `+`)
 
 ## Hints
 
-If the source of the error is clear and common, you may want provide a hint as how to fix it:
+If the source of the error is clear and common, you may want provide a hint as
+how to fix it:
 
 ```{r}
 dplyr::filter(iris, Species = "setosa")
-#> Error: Filter specifications must be named
+#> Error: Filter specifications must be named.
 #> Did you mean `Species == "setosa"`?
 
 ggplot2::ggplot(ggplot2::aes())
@@ -110,7 +125,8 @@ ggplot2::ggplot(ggplot2::aes())
 
 Hints should always end in a question mark.
 
-Hints are particularly important if the source of the error is far away from the root cause:
+Hints are particularly important if the source of the error is far away from the
+root cause:
 
 ```{r}
 # BAD
@@ -123,11 +139,14 @@ mean[[1]]
 
 # BEST
 mean[[1]]
-#> Error: Can't subset a function
+#> Error: Can't subset a function.
 #> Have you forgotten to define a variable named `mean`?
 ```
 
-Good hints are difficult to write because, as above, you want to avoid steering users in the wrong direction. Generally, I avoid writing a hint unless the problem is common, and you can easily find a common pattern of incorrect usage (e.g. by searching StackOverflow).
+Good hints are difficult to write because, as above, you want to avoid steering
+users in the wrong direction. Generally, I avoid writing a hint unless the
+problem is common, and you can easily find a common pattern of incorrect usage
+(e.g. by searching StackOverflow).
 
 ## Punctuation
 
@@ -141,7 +160,7 @@ Good hints are difficult to write because, as above, you want to avoid steering 
     # GOOD
     map_int(1:2, ~ "a")
     #> Error: Each result must be coercible to a single integer:
-    #> * Result 1 is a character vector
+    #> * Result 1 is a character vector.
     
     # BAD
     map_int(1:2, ~ "a")
@@ -186,22 +205,22 @@ More examples gathered from around the tidyverse.
 dplyr::filter(mtcars, cyl)
 #> BEFORE: Argument 2 filter condition does not evaluate to a logical vector 
 #> AFTER:  Each argument must be a logical vector:
-#> * Argument 2 (`cyl`) is an integer vector
+#> * Argument 2 (`cyl`) is an integer vector.
 
 tibble::tribble("x", "y")
 #> BEFORE: Expected at least one column name; e.g. `~name` 
-#> AFTER:  Must supply at least one column name, e.g. `~name`
+#> AFTER:  Must supply at least one column name, e.g. `~name`.
 
 ggplot2::ggplot(data = diamonds) + ggplot2::geom_line(ggplot2::aes(x = cut))
 #> BEFORE: geom_line requires the following missing aesthetics: y
-#> AFTER:  `geom_line()` must have the following aesthetics: `y`
+#> AFTER:  `geom_line()` must have the following aesthetics: `y`.
 
 dplyr::rename(mtcars, cyl = xxx)
 #> BEFORE: `xxx` contains unknown variables
-#> AFTER:  Can't find column `xxx` in `.data`
+#> AFTER:  Can't find column `xxx` in `.data`.
 
 dplyr::arrange(mtcars, xxx)
 #> BEFORE: Evaluation error: object 'xxx' not found.
-#> AFTER:  Can't find column `xxx` in `.data`
+#> AFTER:  Can't find column `xxx` in `.data`.
 ```
 

--- a/08-news.Rmd
+++ b/08-news.Rmd
@@ -2,15 +2,23 @@
 
 ## News bullets
 
-Each user-facing change should be accompanied by a bullet in `NEWS.md`. The goal of the bullet is to briefly describe the change so users of the packages can understand what's changed. This can be similar to the commit message, but often the commit message will be developer  facing, and the bullet will be user facing. 
+Each user-facing change should be accompanied by a bullet in `NEWS.md`. The goal
+of the bullet is to briefly describe the change so users of the packages can
+understand what's changed. This can be similar to the commit message, but often
+the commit message will be developer facing, and the bullet will be user facing.
 
-It is not necessary to describe minor documentation changes. But it's worthwhile to draw attention to sweeping changes, and to new vignettes.
+It is not necessary to describe minor documentation changes. But it's worthwhile
+to draw attention to sweeping changes, and to new vignettes.
 
-New bullets should be added to the top of the file (under the version heading). Organisation of bullets will happen later, during the release process (as described below). 
+New bullets should be added to the top of the file (under the version heading).
+Organisation of bullets will happen later, during the release process (as
+described below).
 
 ### General style
 
-Strive to place the name of the function as close to the beginning of the bullet as possible. A consistent location makes the bullets easier to scan, and easier to organise prior to release.
+Strive to place the name of the function as close to the beginning of the bullet
+as possible. A consistent location makes the bullets easier to scan, and easier
+to organise prior to release.
 
 ```
 # Good
@@ -20,9 +28,11 @@ Strive to place the name of the function as close to the beginning of the bullet
 * Fixed partial argument matches in `ggsave()` (#2355).
 ```
 
-Lines should be wrapped to 80 characters, and each bullet should end in a full stop.
+Lines should be wrapped to 80 characters, and each bullet should end in a full
+stop.
 
-Frame bullets positively (i.e. what now happens, not what used to happen), and use the present tense.
+Frame bullets positively (i.e. what now happens, not what used to happen), and
+use the present tense.
 
 ```
 # Good
@@ -32,7 +42,10 @@ Frame bullets positively (i.e. what now happens, not what used to happen), and u
 * `ggsave()` no longer partially matches argument names (#2355).
 ```
 
-If the bullet is related to a issue, include the issue number. If the contribution was a PR, and the author is not a package author, include their GitHub user name. Both items should be wrapped in parentheses and will generally come before the final period.
+If the bullet is related to a issue, include the issue number. If the
+contribution was a PR, and the author is not a package author, include their
+GitHub user name. Both items should be wrapped in parentheses and will generally
+come before the final period.
 
 ```
 # Good
@@ -45,19 +58,23 @@ If the bullet is related to a issue, include the issue number. If the contributi
   (@wch, #2355)
 ```
 
-Functions and arguments should be wrapped in back ticks, and function names should include parentheses. For more complex features, include longer examples in fenced code blocks (```` ``` ````). These will be useful inspiration when you later write the blog post.
+Functions and arguments should be wrapped in back ticks, and function names
+should include parentheses. For more complex features, include longer examples
+in fenced code blocks (```` ``` ````). These will be useful inspiration when you
+later write the blog post.
 
 ```
 # Good
 * In `stat_bin()`, `binwidth` now also takes functions.
 
 # Bad
-* In the `stat_bin` function, the `binwidth` now also takes functions.
+* In the `stat_bin` function, the `binwidth` argument now also takes functions.
 ```
 
 ### Common patterns
 
-The following exercepts from tidyverse news entries provide helpful templates to follow.
+The following exercepts from tidyverse news entries provide helpful templates to
+follow.
 
 *   New family of functions
 
@@ -69,7 +86,7 @@ The following exercepts from tidyverse news entries provide helpful templates to
     
     * `possibly()`, `safely()` and friends no longer capture interrupts: this
       means that you can now terminate a mapper using one of these with
-      Escape or Ctrl + C (#314)
+      Escape or Ctrl + C (#314).
     ```
     
 *   New function
@@ -77,8 +94,8 @@ The following exercepts from tidyverse news entries provide helpful templates to
     ```
     * New `position_dodge2()` provides enhanced dogding for boxplots...
     
-    * New `stat_qq_line()` makes it easy to add a simple line to a Q-Q plot. This
-      line makes it easier to judge the fit of the theoretical distribution 
+    * New `stat_qq_line()` makes it easy to add a simple line to a Q-Q plot. 
+      This line makes it easier to judge the fit of the theoretical distribution 
       (@nicksolomon).
     ```
 
@@ -111,24 +128,37 @@ The following exercepts from tidyverse news entries provide helpful templates to
 
 ## Organisation
 
-Prior to release, the NEWS file needs to be thoroughly proof read and groomed. 
+Prior to release, the NEWS file needs to be thoroughly proof read and groomed.
 
-If there are many bullets, they should be grouped in to related areas using level 2 headings (`##`). Typically, this will include a catch-all "Minor improvements and bug fixes".  It is not worth while to do this organisation during development, as it's not typically obvious what the groups will be in advance.
+If there are many bullets, they should be grouped into related areas using
+level 2 headings (`##`). Typically, this will include a catch-all "Minor
+improvements and bug fixes". It is not worthwhile to do this organisation
+during development, as it's not typically obvious what the groups will be in
+advance.
 
-Within a section, bullets should be ordered alphabetically by the first function mentioned. If no function is mentioned, place at the top of the section.
+Within a section, bullets should be ordered alphabetically by the first function
+mentioned. If no function is mentioned, place at the top of the section.
 
 ### Breaking changes
 
-If there are API breaking changes (as discovered during revdepchecks) these should also appear in their own section at the top. Each bullet should include a description of the symptoms of the change, and what is needed to fix it. The bullet should also be repeated in the appropriate section.
+If there are API breaking changes (as discovered during revdepchecks) these
+should also appear in their own section at the top. Each bullet should include
+a description of the symptoms of the change, and what is needed to fix it. The
+bullet should also be repeated in the appropriate section.
 
 ```
 ## Breaking changes
 
 * `separate()` now correctly uses -1 to refer to the far right position, 
   instead of -2. If you depended on this behaviour, you'll need to condition
-  on `packageVersion("tidyr") > "0.7.2"`
+  on `packageVersion("tidyr") > "0.7.2"`.
 ```
 
 ## Blog post
 
-For all major and minor releases, the latest news should be turned into a blog post. The blog post should hightlight major user facing changes, and point to the release notes for more deatils. Generally, you should focus on new features and major improvements, including examples showing the new features in action. You don't need to describe minor improvements and bug fixes, as the motivated reader can find these in the release notes.
+For all major and minor releases, the latest news should be turned into a blog
+post. The blog post should hightlight major user-facing changes, and point to
+the release notes for more deatils. Generally, you should focus on new features
+and major improvements, including examples showing the new features in action.
+You don't need to describe minor improvements and bug fixes, as the motivated
+reader can find these in the release notes.


### PR DESCRIPTION
Items from commit messages, below:

**Ch. 2 Syntax**
* Add link for operator precedence.
* Add `#Bad` example for space before comma.
* Add "the" for list structure agreement.
* Make spacing before code chunks consistent.

**Ch. 3 Functions** 
* Link to httr package when mentioned.

**Ch. 4 Pipes**
* Remove the "always have...a new line", since that's just been contradicted above.

**Ch. 5 Code Documentation**
* Add parens after functions listed for single-table verbs.
* Note that code font is created by backticks.

**Ch. 6 Errors**
* Wrap text at 80 characters, consistent w/ other chapters.
* Add full stops to end of error messages (as described best practice).
* Noted inconsistencies between examples and actual in #80.

**Ch. 7 News**
* Reflow text to wrap at 80 characters.
* Add full stop after GOOD News examples.