### PR TITLE
Update average inches expression 02-syntax.Rmd

### DIFF
--- a/02-syntax.Rmd
+++ b/02-syntax.Rmd
@@ -53,7 +53,7 @@ To highlight operator precedence, use parentheses rather than irregular spacing.
 
 ```{r, eval = FALSE}
 # Good
-average <- mean((feet / 12) + inches, na.rm = TRUE)
+average <- mean((feet * 12) + inches, na.rm = TRUE)
 sqrt(x^2 + y^2)
 x <- 1:10
 base::get
@@ -64,7 +64,7 @@ tribble(
 )
 
 # Bad
-average<-mean(feet/12 + inches,na.rm=TRUE)
+average<-mean(feet*12 + inches,na.rm=TRUE)
 sqrt(x ^ 2 + y ^ 2)
 x <- 1 : 10
 base :: get


### PR DESCRIPTION
The average inches expression should be **multiplying** `feet` by 12 instead of **dividing** by 12. This doesn't change the syntax examples but would probably make more sense to the reader.