### PR TITLE
fix example to match rule on spacing around ^

### DIFF
--- a/syntax.Rmd
+++ b/syntax.Rmd
@@ -103,7 +103,7 @@ Place a space before `(` when its used with a keyword like `if`, `for` or `funct
 ```{r, eval = FALSE}
 # Good
 if (debug) show(x)
-plot((x + y) ^ 2, (x - y) ^ 2)
+plot((x + y)^2, (x - y)^2)
 
 # Bad
 if(debug)show(x)


### PR DESCRIPTION
According to changes in the style guide formulated in #46.