### PR TITLE
Correct formula spacing

### DIFF
--- a/news.Rmd
+++ b/news.Rmd
@@ -96,7 +96,7 @@ Many news bullets will be a single sentence. This is typically adequate when des
   }
   ggplot(diamonds, aes(price)) +
     geom_histogram(binwidth = sturges) + 
-    facet_wrap(~ cut)
+    facet_wrap(~cut)
   ```
 ````
 


### PR DESCRIPTION
There is a space in the news example formula that doesn't align with the one-sided formula recommendation.