### PR TITLE
Add google analytics

### DIFF
--- a/_output.yml
+++ b/_output.yml
@@ -1,4 +1,6 @@
 bookdown::gitbook:
+  includes:
+    in_header: [ga_script.html]
   css: style.css
   config:
     toc:

--- a/ga_script.html
+++ b/ga_script.html
@@ -1,0 +1,9 @@
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-115082821-1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'UA-115082821-1');
+</script>


### PR DESCRIPTION
* Add google analytics script as html snippet.
* Add `ga_script.html` to `_output.yml` includes.

- [ ]  Rebuild book following approval
-------
_n.b._ This follows the instructions from @benmarwick's [bookdown-ort](https://github.com/benmarwick/bookdown-ort) (see relevant [section here](https://benmarwick.github.io/bookdown-ort/mods.html#google-analytics)), but uses google tag manager rather than analytics, since that's what we have for the rest of the tidyverse properties.