### PR TITLE
Fix "bad" example

### DIFF
--- a/news.Rmd
+++ b/news.Rmd
@@ -95,7 +95,7 @@ Functions, arguments, and file names should be wrapped in backticks.
 * In `stat_bin()`, `binwidth` now also takes functions.
 
 # Bad
-* In the `stat_bin` function, the `binwidth` argument now also takes functions.
+* In the stat_bin function, the "binwidth" argument now also takes functions.
 ```
 
 Function names should include parentheses. 

--- a/news.Rmd
+++ b/news.Rmd
@@ -92,10 +92,10 @@ Functions, arguments, and file names should be wrapped in backticks.
 
 ```
 # Good
-* In `stat_bin()`, `binwidth` now also takes functions.
+* In `stat_bin()`, `binwidth` now also takes functions and `...` can be used to pass other arguments on to `layer()`.
 
 # Bad
-* In the stat_bin function, the "binwidth" argument now also takes functions.
+* In the stat_bin() function, binwidth now also takes functions and the "..." argument can be used to pass other arguments on to the layer function.
 ```
 
 Function names should include parentheses. 


### PR DESCRIPTION
Obviously, there was a copy-paste glitch between the `Functions, arguments, and file names should be wrapped in backticks` and the `Function names should include parentheses` rules.