### PR TITLE
Space after hashtag in comments as syntax

### DIFF
--- a/syntax.Rmd
+++ b/syntax.Rmd
@@ -413,6 +413,9 @@ contains double quotes and no single quotes.
 
 ## Comments
 
+Each line of a comment should begin with the comment symbol and a single 
+space: `# `
+
 In data analysis code, use comments to record important findings and analysis 
 decisions. If you need comments to explain what your code is doing, consider 
 rewriting your code to be clearer. If you discover that you have more comments 


### PR DESCRIPTION
Single space after hashtag for comments is specified in functions > comments. Seems like syntax > comments, is a more appropriate place for it. At least it's where I looked for it first before I searched elsewhere.