### PR TITLE
Provide guidance on file organization

### DIFF
--- a/package-files.Rmd
+++ b/package-files.Rmd
@@ -21,6 +21,9 @@ documentation should appear first, with private functions appearing after all
 documented functions. If multiple public functions share the same documentation,
 they should all immediately follow the documentation block.
 
+See \@ref(documentation) for more thorough guidance on documenting functions
+in packages.
+
 ```
 # Bad
 help_compute <- function() {
@@ -33,7 +36,28 @@ help_compute <- function() {
 #' ...
 #' @export
 do_something_cool <- function() {
-  # ... even more code
+  # ... even more code ...
   help_compute()
+}
+```
+
+```
+# Good
+#' Lots of functions for doing something cool
+#'
+#' ... Complete documentation ...
+#' @name something-cool
+NULL
+
+#' @describeIn something-cool Get the mean
+#' @export
+get_cool_mean <- function(x) {
+  # ...
+}
+
+#' @describeIn something-cool Get the sum
+#' @export
+get_cool_sum <- function(x) {
+  # ...
 }
 ```

--- a/package-files.Rmd
+++ b/package-files.Rmd
@@ -13,3 +13,27 @@ The majority of advice in Chapter \@ref(files) also applies to files in packages
 * Deprecated functions should live in a file with `deprec-` prefix.
 
 * Compatibility functions should live in a file with `compat-` prefix.
+
+## Organisation
+
+In a file that contains multiple functions, public functions and their
+documentation should appear first, with private functions appearing after all
+documented functions. If multiple public functions share the same documentation,
+they should all immediately follow the documentation block.
+
+```
+# Bad
+help_compute <- function() {
+  # ... Lots of code ...
+}
+
+#' My public function
+#'
+#' This is where the documentation of my function begins.
+#' ...
+#' @export
+do_something_cool <- function() {
+  # ... even more code
+  help_compute()
+}
+```


### PR DESCRIPTION
Languages differ in preferences for how public and private functions/ methods should be organized.

Since the Roxygen header is often essential to understanding the rest of the file, the public, well-documented functions should appear first.