### PR TITLE
Advise sentence case in commit msgs

### DIFF
--- a/git.Rmd
+++ b/git.Rmd
@@ -6,6 +6,7 @@ Follow [standard git commit message advice](https://chris.beams.io/posts/git-com
 
 * The first line is the subject, and should summarise the changes in the commit
   in under 50 characters.
+  Use sentence case, but no period at the end.
   
 * If additional details are required, add a blank line, and then provide
   explanation and context in paragraph format.


### PR DESCRIPTION
I was recently advised to use sentence case in https://github.com/r-lib/vctrs/pull/1327.

The linked resource already [includes this norm](https://chris.beams.io/posts/git-commit/), but it may be easy to miss and bad case really sticks out in a commit history.