### PR TITLE
Mix of minor details

### DIFF
--- a/documentation.Rmd
+++ b/documentation.Rmd
@@ -36,7 +36,7 @@ more complex formatting like a bulleted list.
 #' 
 #' * `map()` returns a list or a data frame
 #' * `map_lgl()`, `map_int()`, `map_dbl()` and `map_chr()` return 
-#'     vectors of the corresponding type (or die trying); 
+#'    vectors of the corresponding type (or die trying); 
 #' * `map_dfr()` and `map_dfc()` return data frames created by row-binding 
 #'    and column-binding respectively. They require dplyr to be installed.
 ```

--- a/package-files.Rmd
+++ b/package-files.Rmd
@@ -24,7 +24,7 @@ they should all immediately follow the documentation block.
 See \@ref(documentation) for more thorough guidance on documenting functions
 in packages.
 
-```
+```{r}
 # Bad
 help_compute <- function() {
   # ... Lots of code ...
@@ -41,7 +41,7 @@ do_something_cool <- function() {
 }
 ```
 
-```
+```{r}
 # Good
 #' Lots of functions for doing something cool
 #'

--- a/syntax.Rmd
+++ b/syntax.Rmd
@@ -435,7 +435,7 @@ do_something_very_complicated("that", requires, many, arguments,
                               )
 ```
 
-As described under [Argument names], you can omit the argument names
+As described under [Named arguments](#argument-names), you can omit the argument names
 for very common arguments (i.e. for arguments that are used in almost every 
 invocation of the function). Short unnamed arguments can also go on the same 
 line as the function name, even if the whole function call spans multiple lines.

--- a/syntax.Rmd
+++ b/syntax.Rmd
@@ -212,7 +212,7 @@ There are a few exceptions, which should never be surrounded by spaces:
     
 ### Extra spaces
 
-Adding extra spaces ok if it improves alignment of `=` or `<-`. 
+Adding extra spaces is ok if it improves alignment of `=` or `<-`. 
 
 ```{r, eval = FALSE}
 # Good


### PR DESCRIPTION
* The examples in `package-files.Rmd` should now be styled like the rest of the code by labeling them as R code (rather than just generally code) - not sure if that was an oversight or if this change would now break anything?
* The bullet list in `documentation.Rmd` which I changed had one paragraph with an indentation and another without. The other bullet list didn't have indentation so I removed it.
* The other parts are one missing verb and one link to a different section which didn't go anywhere.